### PR TITLE
Configure request waits

### DIFF
--- a/mrmime/__init__.py
+++ b/mrmime/__init__.py
@@ -32,8 +32,8 @@ _mr_mime_cfg = {
     'request_retry_delay': 5,           # Number of seconds to wait between request retries. Will be shorter if multiple hash keys and/or proxies are available.
     # --- misc requests
     'scan_delay': 10,                   # Wait at least this long between 2 GMO requests
-    'encounter_action_delay': 2.25,     # Wait at least this long before performing encounter action
-    'min_request_wait': 0.5,            # Minimum time to wait between requests
+    'encounter_delay': 2.25,     # Wait at least this long before performing encounter action
+    'min_request_delay': 0.5,            # Minimum time to wait between requests
     # --- logging
     'debug_log': False,                 # If MrMime should output debug logging
     'log_file': None,                   # If given MrMime also logs into this file

--- a/mrmime/__init__.py
+++ b/mrmime/__init__.py
@@ -32,6 +32,8 @@ _mr_mime_cfg = {
     'request_retry_delay': 5,           # Number of seconds to wait between request retries. Will be shorter if multiple hash keys and/or proxies are available.
     # --- misc requests
     'scan_delay': 10,                   # Wait at least this long between 2 GMO requests
+    'encounter_action_delay': 2.25,     # Wait at least this long before performing encounter action
+    'min_request_wait': 0.5,            # Minimum time to wait between requests
     # --- logging
     'debug_log': False,                 # If MrMime should output debug logging
     'log_file': None,                   # If given MrMime also logs into this file

--- a/mrmime/__init__.py
+++ b/mrmime/__init__.py
@@ -32,8 +32,8 @@ _mr_mime_cfg = {
     'request_retry_delay': 5,           # Number of seconds to wait between request retries. Will be shorter if multiple hash keys and/or proxies are available.
     # --- misc requests
     'scan_delay': 10,                   # Wait at least this long between 2 GMO requests
-    'encounter_delay': 2.25,     # Wait at least this long before performing encounter action
-    'min_request_delay': 0.5,            # Minimum time to wait between requests
+    'encounter_delay': 2.25,            # Wait at least this long before performing encounter action
+    'min_request_delay': 0.5,           # Minimum time to wait between requests
     # --- logging
     'debug_log': False,                 # If MrMime should output debug logging
     'log_file': None,                   # If given MrMime also logs into this file

--- a/mrmime/pogoaccount.py
+++ b/mrmime/pogoaccount.py
@@ -449,7 +449,7 @@ class POGOAccount(object):
             encounter_id=encounter_id,
             spawn_point_id=spawn_point_id,
             player_latitude=latitude,
-            player_longitude=longitude), action=self.cfg['encounter_action_delay'])
+            player_longitude=longitude), action=self.cfg['encounter_delay'])
 
     def req_catch_pokemon(self, encounter_id, spawn_point_id, ball,
                           normalized_reticle_size, spin_modifier):
@@ -608,12 +608,12 @@ class POGOAccount(object):
         # Wait until a previous user action gets completed
         if action:
             now = time.time()
-            # wait for the time required, or at least a configured min_request_wait
-            min_wait = self.cfg['min_request_wait']
-            if self._last_action > now + min_wait:
+            # wait for the time required, or at least a configured min_request_delay (default 0.5)
+            min_sleep = self.cfg['min_request_delay']
+            if self._last_action > now + min_sleep:
                 time.sleep(self._last_action - now)
             else:
-                time.sleep(min_wait)
+                time.sleep(min_sleep)
 
         req_method_list = copy.deepcopy(request._req_method_list)
 

--- a/mrmime/pogoaccount.py
+++ b/mrmime/pogoaccount.py
@@ -449,7 +449,7 @@ class POGOAccount(object):
             encounter_id=encounter_id,
             spawn_point_id=spawn_point_id,
             player_latitude=latitude,
-            player_longitude=longitude), action=self.cfg['encounter_delay'])
+            player_longitude=longitude), action=float(self.cfg['encounter_delay']))
 
     def req_catch_pokemon(self, encounter_id, spawn_point_id, ball,
                           normalized_reticle_size, spin_modifier):
@@ -609,7 +609,7 @@ class POGOAccount(object):
         if action:
             now = time.time()
             # wait for the time required, or at least a configured min_request_delay (default 0.5)
-            min_sleep = self.cfg['min_request_delay']
+            min_sleep = float(self.cfg['min_request_delay'])
             if self._last_action > now + min_sleep:
                 time.sleep(self._last_action - now)
             else:

--- a/mrmime/pogoaccount.py
+++ b/mrmime/pogoaccount.py
@@ -611,10 +611,8 @@ class POGOAccount(object):
             # wait for the time required, or at least a configured min_request_delay (default 0.5)
             min_sleep = float(self.cfg['min_request_delay'])
             if self._last_action > now + min_sleep:
-                self.log_debug("Sleeping for {}".format(self._last_action - now))
                 time.sleep(self._last_action - now)
             else:
-                self.log_debug("Sleeping for {}".format(min_sleep))
                 time.sleep(min_sleep)
 
         req_method_list = copy.deepcopy(request._req_method_list)

--- a/mrmime/pogoaccount.py
+++ b/mrmime/pogoaccount.py
@@ -613,6 +613,7 @@ class POGOAccount(object):
             if self._last_action > now + min_sleep:
                 time.sleep(self._last_action - now)
             else:
+                self.log_debug("Sleeping for {}".format(min_sleep))
                 time.sleep(min_sleep)
 
         req_method_list = copy.deepcopy(request._req_method_list)

--- a/mrmime/pogoaccount.py
+++ b/mrmime/pogoaccount.py
@@ -449,7 +449,7 @@ class POGOAccount(object):
             encounter_id=encounter_id,
             spawn_point_id=spawn_point_id,
             player_latitude=latitude,
-            player_longitude=longitude), action=2.25)
+            player_longitude=longitude), action=self.cfg['encounter_action_delay'])
 
     def req_catch_pokemon(self, encounter_id, spawn_point_id, ball,
                           normalized_reticle_size, spin_modifier):
@@ -608,11 +608,12 @@ class POGOAccount(object):
         # Wait until a previous user action gets completed
         if action:
             now = time.time()
-            # wait for the time required, or at least a half-second
-            if self._last_action > now + .5:
+            # wait for the time required, or at least a configured min_request_wait
+            min_wait = self.cfg['min_request_wait']
+            if self._last_action > now + min_wait:
                 time.sleep(self._last_action - now)
             else:
-                time.sleep(0.5)
+                time.sleep(min_wait)
 
         req_method_list = copy.deepcopy(request._req_method_list)
 

--- a/mrmime/pogoaccount.py
+++ b/mrmime/pogoaccount.py
@@ -611,6 +611,7 @@ class POGOAccount(object):
             # wait for the time required, or at least a configured min_request_delay (default 0.5)
             min_sleep = float(self.cfg['min_request_delay'])
             if self._last_action > now + min_sleep:
+                self.log_debug("Sleeping for {}".format(self._last_action - now))
                 time.sleep(self._last_action - now)
             else:
                 self.log_debug("Sleeping for {}".format(min_sleep))


### PR DESCRIPTION
## Description
Allows options to configure request waits for encounters.
`encounter_delay` sets the time to wait after an encounter (default 2.25 seconds)
`min_request_delay` is the minimum time to wait after any request (default 0.5 seconds)

If encounter_delay is set below min_request_delay, the encounter_delay will be ignored and it will wait min_request_delay seconds.

## Motivation and Context
This will allow PGScout to perform encounters much faster. I have gotten values up to 8000/hr in testing. Added benefit that the feature is hidden in Mr Mime.

## How Has This Been Tested?
Tested on my production environment with PGScout

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
